### PR TITLE
Buffs Techies's passive land mine charge gain.

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_techies.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_techies.lua
@@ -59,7 +59,7 @@ function LandMineCharges( keys )
 	-- Parameters
 	local levels_per_charge = ability:GetLevelSpecialValueFor("levels_per_charge", ability_level)
 	local charge_cooldown = ability:GetLevelSpecialValueFor("charge_cooldown", ability_level)
-	local max_charges = math.floor( caster:GetLevel() / levels_per_charge + 1 )
+	local max_charges = math.floor((caster:GetLevel() * 2) / levels_per_charge + 1 )
 	local current_charges = caster:GetModifierStackCount(modifier_charges, caster)
 	local actual_cooldown = math.ceil( charge_cooldown / max_charges)
 
@@ -75,9 +75,9 @@ function LandMineCharges( keys )
 	-- Increment the timer and add charges if appropriate
 	else
 
-		-- If the caster has a scepter, increment the timer twice as fast
+		-- If the caster has a scepter, increment the timer four times as fast
 		if scepter then
-			caster.land_mine_charge_counter = caster.land_mine_charge_counter + 2
+			caster.land_mine_charge_counter = caster.land_mine_charge_counter + 4
 		else
 			caster.land_mine_charge_counter = caster.land_mine_charge_counter + 1
 		end
@@ -87,8 +87,12 @@ function LandMineCharges( keys )
 			-- Reset timer
 			caster.land_mine_charge_counter = 0
 
-			-- If possible, add a charge
-			AddStacks(ability, caster, caster, modifier_charges, 1, true)
+			-- If possible, add a charge, add two if they've got a scepter.
+			if scepter then
+				AddStacks(ability, caster, caster, modifier_charges, 2, true)
+			else
+				AddStacks(ability, caster, caster, modifier_charges, 1, true)
+			end
 		end
 	end
 end


### PR DESCRIPTION
I've found that it really stops being helpful mid to late game because of how slowly the charges build up, and how much health heroes have, so:

Scepters now quadruple the speed at which you gain mines.
Scepters now cause you to gain two charges at a time.
Your passive charge gain rate now takes your level into account more heavily.