### PR TITLE
Adds a CONTRIBUTING.md file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+Pull Requests adding new features or suggestions are not to be made. Please file suggestions at the following reddit link.
+
+https://www.reddit.com/r/dotaimba/comments/4rdz1q/bugssuggestions_thread_part_7_firefrog_u_fuck_fix/
+
+Bug fixes are okay, however.


### PR DESCRIPTION
The contents of this file will show up in the description box of any PRs opened by default, like the commit descriptions usually do and potentially warn confused coders away from coding the suggestions as PRs and wasting effort.
