### PR TITLE
Fixed AA ulti preventing Reincarnation and WK Aghs

### DIFF
--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -29999,6 +29999,8 @@
 
 				"ThinkInterval"						"0.2"
 
+				"Attributes"				"MODIFIER_ATTRIBUTE_PERMANENT"
+
 				"OnIntervalThink"
 				{
 					"RunScript"
@@ -30029,6 +30031,8 @@
 				"IsHidden"							"1"
 				"IsBuff"							"1"
 				"IsPurgable"						"0"
+
+				"Attributes"				"MODIFIER_ATTRIBUTE_PERMANENT"
 
 				"Duration"							"%aura_linger"
 			}


### PR DESCRIPTION
Added the attribute "permanent" to the Reincarnation and Reincranation Aghs modifiers to allow them to work through instant kill modifiers like AA Ulti. All tests seem to verify that this works!