### PR TITLE
Fixed bug with Clinkz Aghs

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_clinkz.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_clinkz.lua
@@ -242,12 +242,12 @@ function DeathPact( keys )
 		-- If the target is not an illusion or an ally, deal damage
 		if target:IsRealHero() then
 			if target:GetTeam() ~= caster:GetTeam() then
-				ApplyDamage({attacker = caster, victim = target, ability = ability, damage = target_health * damage_hero / 100, damage_type = DAMAGE_TYPE_PURE})
-
 				-- If the caster has a scepter, apply the death pact modifier
 				if scepter then
 					ability:ApplyDataDrivenModifier(caster, target, modifier_target, {})
 				end
+				
+				ApplyDamage({attacker = caster, victim = target, ability = ability, damage = target_health * damage_hero / 100, damage_type = DAMAGE_TYPE_PURE})
 			end
 		
 		-- If it's an illusion, simply kill it


### PR DESCRIPTION
Fixed a bug where Clinkz would not be awarded a stack of Death Pact when Death pact itself dealt the killing blow. The fix simply involves moving the step where the "aghs modifier" is added to the hero before the step where damage is applied.