### PR TITLE
Lazy IMBA Silencer

### DIFF
--- a/game/dota_addons/dota_imba/scripts/npc/herolist.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/herolist.txt
@@ -68,7 +68,7 @@
 	"npc_dota_hero_death_prophet" "1"
 	"npc_dota_hero_ursa" "1"
 	"npc_dota_hero_bounty_hunter" "1"
-	"npc_dota_hero_silencer" "0"
+	"npc_dota_hero_silencer" "1"
 	"npc_dota_hero_spirit_breaker" "1"
 	"npc_dota_hero_invoker" "1"
 	"npc_dota_hero_clinkz" "1"

--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -26866,6 +26866,521 @@
 	}
 
 	//=================================================================================================================
+	// Silencer's Arcane Curse
+	//=================================================================================================================
+	"imba_silencer_arcane_curse"
+	{
+		// General
+		//--------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags" 				"DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS | DOTA_UNIT_TARGET_FLAG_PLAYER_CONTROLLED"
+		"AbilityTextureName"					"silencer_curse_of_the_silent"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_NO"
+
+		// Precache
+		//---------------------------------------------
+		"precache"
+		{
+			"particle"							"particles/units/heroes/hero_silencer/silencer_curse.vpcf"
+			"particle"							"particles/units/heroes/hero_silencer/silencer_curse_aoe.vpcf"
+			"soundfile"							"soundevents/game_sounds_heroes/game_sounds_silencer.vsndevts"
+		}
+
+		// Casting
+		//---------------------------------------------
+		"AbilityCastRange"				"1000"
+		"AbilityCastPoint"				"0.3"
+		"AoERadius"						"425"
+		
+		// Time		
+		//---------------------------------------------
+		"AbilityCooldown"				"20.0 18.0 16.0 14.0"
+
+		// Cost
+		//---------------------------------------------
+		"AbilityManaCost"				"75 95 115 135"
+		
+		// Special
+		//---------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage_per_second"	"14 22 30 38"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"425"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"base_duration"		"6"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"penalty_duration"	"4"
+			}
+			"05"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"curse_slow"		"-9 -12 -15 -18"
+			}
+			"06"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"tick_rate"			"1.0"
+			}
+		}
+
+		// Spell Actions (based on Pizzalol's SpellLibrary)
+		//---------------------------------------------
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{	
+				"EffectName"	"particles/units/heroes/hero_silencer/silencer_curse_aoe.vpcf"
+				"EffectAttachType"	"start_at_customorigin"
+				"TargetPoint"	"POINT"
+
+				"ControlPoints"
+				{
+					"01"	"%radius 0 0"
+				}
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Silencer.Curse.Cast"
+				"Target"		"CASTER"
+			}
+
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"	"POINT"
+					"Radius"	"%radius"
+
+					"Teams"  	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types"  	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+					"Flags"  	"DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS | DOTA_UNIT_TARGET_FLAG_PLAYER_CONTROLLED"
+				}
+				
+				"Action"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"hero/hero_silencer.lua"
+						"Function"		"ArcaneCurseCast"
+
+						"Target"		"TARGET"
+						"curse_debuff" 	"modifier_imba_arcane_curse_debuff"
+					}
+				}
+			}
+		}
+	}
+
+	//=================================================================================================================
+	// Silencer's Glaive of Wisdom
+	//=================================================================================================================
+	"imba_silencer_glaives_of_wisdom"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass" 						"ability_datadriven"
+		"AbilityBehavior" 					"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST | DOTA_ABILITY_BEHAVIOR_ATTACK"
+		"AbilityUnitTargetTeam" 			"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType" 			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType" 			"DAMAGE_TYPE_PURE"
+		"AbilityTextureName" 				"silencer_glaives_of_wisdom"
+		"SpellImmunityType"					"SPELL_IMMUNITY_ENEMIES_NO"
+
+		// Cost and cast stuff
+		//-------------------------------------------------------------------------------------------------------------		
+		"AbilityCastPoint"					"0.0"
+		"AbilityCastRange" 					"600"
+		"AbilityCooldown"					"0.0"
+		"AbilityManaCost" 					"15"
+
+		// Precache
+		//-------------------------------------------------------------------------------------------------------------
+		"precache"
+		{
+			"soundfile"						"soundevents/game_sounds_heroes/game_sounds_silencer.vsndevts"
+			"particle"						"particles/units/heroes/hero_silencer/silencer_glaives_of_wisdom.vpcf"
+		}
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"intellect_damage_pct"	"45.0 70.0 95.0 120.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"modifier_imba_glaives_of_wisdom"
+			{
+				"Passive"               		"1"
+				"IsHidden"						"1"
+				
+				"Orb"
+				{
+					"Priority"					"DOTA_ORB_PRIORITY_ABILITY"
+					"ProjectileName"			"particles/units/heroes/hero_silencer/silencer_glaives_of_wisdom.vpcf"
+					"CastAttack"				"1"
+				}
+
+				"OnOrbFire"
+				{
+					"FireSound"
+					{
+						"EffectName"			"Hero_Silencer.GlaivesOfWisdom"
+						"Target"				"CASTER"
+					}
+					"SpendMana"
+					{
+						"Mana"					"%AbilityManaCost"
+					}
+				}
+
+				"OnOrbImpact"
+				{
+					"FireSound"
+					{
+						"EffectName"			"Hero_Silencer.GlaivesOfWisdom.Damage"
+						"Target"				"TARGET"
+					}
+
+					"RunScript"
+					{
+						"ScriptFile"			"hero/hero_silencer.lua"
+						"Function"				"IntToDamage"
+						"Target"				"TARGET"
+					}
+				}
+			}
+		}
+	}
+
+	//=================================================================================================================
+	// Silencer's Last Word
+	// (Based on Pizzalol's SpellLibrary)
+	//=================================================================================================================
+	"imba_silencer_last_word"
+	{
+		// General
+		//--------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags" 				"DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS"
+		"AbilityTextureName"					"silencer_last_word"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_NO"
+
+		// Precache
+		//---------------------------------------------
+		"precache"
+		{
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_silencer.vsndevts"		
+			"particle"			"particles/units/heroes/hero_silencer/silencer_last_word.vpcf"
+			"particle" 			"particles/units/heroes/hero_silencer/silencer_last_word_status.vpcf"
+			"particle"			"particles/generic_gameplay/generic_silence.vpcf"
+		}
+
+		// Casting
+		//---------------------------------------------
+		"AbilityCastRange"				"900"
+		"AbilityCastPoint"				"0.3"
+		
+		// Time		
+		//---------------------------------------------
+		"AbilityCooldown"				"30.0 24.0 18.0 12.0"
+
+		// Cost
+		//---------------------------------------------
+		"AbilityManaCost"				"115"
+		
+		// Special
+		//---------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"150 200 250 300"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"4"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"debuff_duration"	"3 4 5 6"
+			}
+		}
+
+		// Spell Actions
+		//---------------------------------------------
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Silencer.LastWord.Cast"
+				"Target"		"TARGET"
+			}	
+
+			"ApplyModifier"
+			{
+				"ModifierName"  "modifier_imba_last_word"
+				"Target"		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"modifier_imba_last_word"
+			{
+				"IsDebuff"			"1"
+				"Duration"			"%duration"
+				"ThinkInterval"		"%duration"
+				"EffectName"		"particles/units/heroes/hero_silencer/silencer_last_word_status.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_PROVIDES_VISION"	"MODIFIER_STATE_VALUE_ENABLED"	
+				}
+				
+				"OnIntervalThink"
+				{
+
+					"FireSound"
+					{
+						"EffectName"		"Hero_Silencer.LastWord.Damage"
+						"Target"			"TARGET"
+					}
+
+					"ApplyModifier"
+					{
+						"ModifierName"		"modifier_imba_last_word_silence"
+						"Target"			"TARGET"
+					}
+
+					"RunScript"
+					{
+						"ScriptFile"		"hero/hero_silencer.lua"
+						"Function"			"LastWordDamageNoCast"
+						"Target"			"TARGET"
+
+						"modifier"			"modifier_imba_last_word"
+					}
+				}
+
+				"OnCreated"
+				{
+					"FireSound"
+					{
+						"EffectName"		"Hero_Silencer.LastWord.Target"
+						"Target"			"TARGET"
+					}
+				}
+
+				"OnSpentMana"
+				{
+					"RunScript"
+					{
+						"ScriptFile"		"hero/hero_silencer.lua"
+						"Function"			"LastWordDamage"
+						"Target"			"UNIT"
+
+						"modifier"			"modifier_imba_last_word"
+					}
+				}
+
+				"OnAbilityExecuted"
+				{
+					"RunScript"
+					{
+						"ScriptFile"		"hero/hero_silencer.lua"
+						"Function"			"LastWordDebuff"
+						"Target"			"UNIT"
+
+						"modifier"			"modifier_imba_last_word"
+						"silence_modifier"	"modifier_imba_last_word_silence"
+
+						"sound"				"Hero_Silencer.LastWord.Target"
+						"damage_sound"		"Hero_Silencer.LastWord.Damage"
+					}
+				}
+
+				"OnAbilityEndChannel"
+				{
+					"RunScript"
+					{
+						"ScriptFile"		"hero/hero_silencer.lua"
+						"Function"			"LastWordDebuff"
+						"Target"			"UNIT"
+
+						"modifier"			"modifier_imba_last_word"
+						"silence_modifier"	"modifier_imba_last_word_silence"
+
+						"sound"				"Hero_Silencer.LastWord.Target"
+						"damage_sound"		"Hero_Silencer.LastWord.Damage"
+					}
+				}
+			}
+
+			"modifier_imba_last_word_silence"
+			{
+				"IsDebuff"					"1"
+				"Duration"					"%debuff_duration"
+				"EffectName"				"particles/generic_gameplay/generic_silence.vpcf"
+				"EffectAttachType"			"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_SILENCED"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+	}
+
+	//=================================================================================================================
+	// Silencer's Global Silence
+	// (Based on Pizzalol's SpellLibrary)
+	//=================================================================================================================
+	"imba_silencer_global_silence"
+	{
+		// General
+		//--------------------------------------------
+		"BaseClass"					"ability_datadriven"
+		"AbilityType"				"DOTA_ABILITY_TYPE_ULTIMATE"
+		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"		"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"		"DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"	"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityTextureName" 		"silencer_global_silence"
+		"SpellImmunityType"			"SPELL_IMMUNITY_ENEMIES_YES"
+
+		// Casting
+		//---------------------------------------------
+		"AbilityCastPoint"			"0.2"
+		"AbilityCooldown"			"120.0 110.0 100.0"
+
+		// Time
+		//---------------------------------------------
+		"AbilityDuration"			"5.0 7.0 9.0"
+
+		// Precache
+		//---------------------------------------------
+		"precache"
+		{
+			"soundfile"				"soundevents/game_sounds_heroes/game_sounds_silencer.vsndevts"		
+			"particle"				"particles/units/heroes/hero_silencer/silencer_global_silence.vpcf"		
+		}
+
+		// Cost
+		//--------------------------------------------
+		"AbilityManaCost" 			"250 375 500"
+
+		// Special
+		//--------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"5.0 7.0 9.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			//Only applies the sound on caster, otherwise RIP headphones in 10v10
+			"FireSound"
+			{
+				"EffectName"		"Hero_Silencer.GlobalSilence.Cast"
+				"Target"			"CASTER"
+			}
+
+			"FireSound"
+			{
+				"EffectName"		"Hero_Silencer.GlobalSilence.Effect"
+				"Target"			"CASTER"
+			}
+
+			"FireEffect"
+			{
+				"EffectName"		"particles/units/heroes/hero_silencer/silencer_global_silence.vpcf"
+				"EffectAttachType"	"follow_origin"
+				"Target"			"CASTER"
+			}
+
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center" 		"CASTER"
+					"Radius" 		"GLOBAL"
+					"Teams"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 		"DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+					"Flags" 		"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+
+				"Action"
+				{
+					"RunScript"
+					{
+						"ScriptFile"		"hero/hero_silencer.lua"
+						"Function"			"GlobalSilenceCast"
+						"Target"			"TARGET"
+
+						"curse_name"		"imba_silencer_arcane_curse"
+						"curse_modifier"	"modifier_imba_arcane_curse_debuff"
+						"silence_modifier"	"modifier_imba_global_silence"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"modifier_imba_global_silence"
+			{
+				"IsDebuff"			"1"
+				"IsPurgable"		"1"
+				"Duration"			"%duration"
+
+				"EffectName"		"particles/generic_gameplay/generic_silence.vpcf"
+				"EffectAttachType"	"follow_overhead"			
+
+				"States"
+				{
+					"MODIFIER_STATE_SILENCED"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+	}
+
+	//=================================================================================================================
 	// Sniper's Headshot
 	//=================================================================================================================
 	"imba_sniper_headshot"

--- a/game/dota_addons/dota_imba/scripts/npc/npc_heroes_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_heroes_custom.txt
@@ -1529,12 +1529,14 @@
 	{
 		"override_hero"				"npc_dota_hero_silencer"
 
+		"AttackRate"				"1.5"
+
 		"AttributeIntelligenceGain"	"3.0"
 
-		//"Ability1"					"imba_silencer_curse_of_the_silent"
-		//"Ability2"					"imba_silencer_glaives_of_wisdom"
-		//"Ability3"					"imba_silencer_last_word"
-		//"Ability4"					"imba_silencer_global_silence"
+		"Ability1"					"imba_silencer_arcane_curse"
+		"Ability2"					"imba_silencer_glaives_of_wisdom"
+		"Ability3"					"imba_silencer_last_word"
+		"Ability4"					"imba_silencer_global_silence"
 		"Ability5"					"attribute_bonus_int"
 
 		"ProjectileModel"			"particles/units/heroes/hero_silencer/silencer_base_attack.vpcf"
@@ -1608,26 +1610,6 @@
 		"Ability5"					"attribute_bonus_agi"
 
 		"ProjectileSpeed"			"900"
-	}
-
-	//=================================================================================================================
-	// HERO: Silencer
-	//=================================================================================================================
-	"npc_imba_hero_silencer"
-	{
-		"override_hero"				"npc_dota_hero_silencer"
-
-		"AttackRate"				"1.5"
-
-		"AttributeIntelligenceGain"		"3.0"
-
-		//"Ability1"					"imba_silencer_curse_of_the_silent"
-		//"Ability2"					"imba_silencer_glaives_of_wisdom"
-		//"Ability3"					"imba_silencer_last_word"
-		//"Ability4"					"imba_silencer_global_silence"
-		"Ability5"					"attribute_bonus_int"
-
-		"ProjectileModel"			"particles/units/heroes/hero_silencer/silencer_base_attack.vpcf"
 	}
 
 	//=================================================================================================================

--- a/game/dota_addons/dota_imba/scripts/vscripts/addon_game_mode.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/addon_game_mode.lua
@@ -24,7 +24,9 @@ function Precache( context )
 	LinkLuaModifier("modifier_imba_speed_limit_break", "modifier/modifier_imba_speed_limit_break.lua", LUA_MODIFIER_MOTION_NONE )
 	LinkLuaModifier("modifier_imba_haste_boots_speed_break", "modifier/modifier_imba_haste_boots_speed_break.lua", LUA_MODIFIER_MOTION_NONE )
 	LinkLuaModifier("modifier_imba_chronosphere_ally_slow", "modifier/modifier_imba_chronosphere_ally_slow.lua", LUA_MODIFIER_MOTION_NONE )
-
+	LinkLuaModifier("modifier_imba_arcane_curse_debuff", "modifier/modifier_imba_arcane_curse_debuff.lua", LUA_MODIFIER_MOTION_NONE )
+	LinkLuaModifier("modifier_imba_silencer_int_steal", "modifier/modifier_imba_silencer_int_steal.lua", LUA_MODIFIER_MOTION_NONE )
+	
 	-- Items
 	PrecacheResource("particle", "particles/econ/items/effigies/status_fx_effigies/gold_effigy_ambient_dire_lvl2.vpcf", context)
 	PrecacheResource("soundfile", "soundevents/game_sounds_heroes/game_sounds_brewmaster.vsndevts", context)

--- a/game/dota_addons/dota_imba/scripts/vscripts/events.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/events.lua
@@ -176,6 +176,24 @@ function GameMode:OnNPCSpawned(keys)
 	local npc = EntIndexToHScript(keys.entindex)
 
 	-------------------------------------------------------------------------------------------------
+	-- IMBA: Replace Silencer Int Steal with IMBA version
+	--
+	-- Unfortunately, needs to be done every time Silencer spawns as his modifier is permanently
+	-- embedded into his character and he'll gain it every time he spawns
+	-------------------------------------------------------------------------------------------------
+	if npc:IsRealHero() then
+		Timers:CreateTimer(1, function()
+				if npc:HasModifier("modifier_silencer_int_steal") then
+					npc:RemoveModifierByName("modifier_silencer_int_steal")
+					-- Only add the modifier once, since it persists through death and whatnot
+					if not npc:HasModifier("modifier_imba_silencer_int_steal") then
+						npc:AddNewModifier(npc, nil, "modifier_imba_silencer_int_steal", {steal_range = 925, steal_amount = 2})
+					end
+				end
+		end)
+	end
+
+	-------------------------------------------------------------------------------------------------
 	-- IMBA: Arc Warden clone handling
 	-------------------------------------------------------------------------------------------------
 

--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_enigma.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_enigma.lua
@@ -464,18 +464,22 @@ function BlackHoleEnd( keys )
 	local caster = keys.caster
 	local sound_stop = keys.sound_stop
 
-	-- Stop all sounds from playing
-	caster.black_hole_dummy:StopSound("Hero_Enigma.Black_Hole")
-	caster.black_hole_dummy:StopSound("Imba.EnigmaBlackHoleTi5")
+	if not caster:IsNull() then
+		-- Play the end sound
+		caster:EmitSound(sound_stop)
+		
+		if caster.black_hole_dummy ~= nil then
+			-- Stop all sounds from playing
+			caster.black_hole_dummy:StopSound("Hero_Enigma.Black_Hole")
+			caster.black_hole_dummy:StopSound("Imba.EnigmaBlackHoleTi5")
 
-	-- Play the end sound
-	caster:EmitSound(sound_stop)
+			-- Destroy the dummy
+			caster.black_hole_dummy:Destroy()
 
-	-- Destroy the dummy
-	caster.black_hole_dummy:Destroy()
-
-	-- Clear global variable
-	caster.black_hole_center = nil
+			-- Clear global variable
+			caster.black_hole_center = nil
+		end
+	end
 end
 
 function BlackHoleDebuffStart( keys )

--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_silencer.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_silencer.lua
@@ -1,0 +1,165 @@
+function ArcaneCurseCast( keys )
+	local caster = keys.caster
+	local target = keys.target
+	local ability = keys.ability
+	local curse_debuff = keys.curse_debuff
+
+	target:AddNewModifier(caster, ability, curse_debuff, nil)
+end
+
+function IntToDamage( keys )
+	local caster = keys.caster
+	local target = keys.target
+	local ability = keys.ability
+
+	local caster_int = caster:GetIntellect()
+	local glaive_damage = ability:GetLevelSpecialValueFor("intellect_damage_pct", ( ability:GetLevel() - 1 ))
+
+	local damage_table = {
+		victim = target,
+		attacker = caster,
+		damage = caster_int * glaive_damage / 100,
+		damage_type = ability:GetAbilityDamageType(),
+		ability = ability
+	}
+
+	ApplyDamage( damage_table )
+end
+
+function LastWordDamage( keys )
+	local caster = keys.caster
+	local target = keys.unit
+	local event_ability = keys.event_ability
+	local modifier = keys.modifier
+	local ability = keys.ability
+
+	local target_modifier = target:FindModifierByName(modifier)
+	if target_modifier and ( not event_ability:IsItem() ) then
+		if target_modifier.damage_applied == nil then
+			-- Need to check if we are using an autoattack ability (orbs)
+			-- ...this is going to be ugly
+			local exceptions = {
+				["imba_drow_ranger_frost_arrows"] = true,
+				["imba_drow_ranger_frost_arrows_mark1"] = true,
+				["imba_drow_ranger_frost_arrows_mark2"] = true,
+				["imba_drow_ranger_frost_arrows_mark3"] = true,
+				["imba_silencer_glaives_of_wisdom"] = true, --hoist with his own petard
+				["imba_obsidian_destroyer_arcane_orb"] = true,
+				["imba_clinkz_searing_arrows"] = true, --doesn't cost mana, but I want to be safe
+				--These will need to be removed when they are imbafied
+				["viper_poison_attack"] = true,
+				["doom_bringer_infernal_blade"] = true,
+				["tusk_walrus_punch"] = true,
+				--Future imbafied autoattacks, based on name conventions
+				["imba_viper_poison_attack"] = true,
+				["imba_doom_bringer_infernal_blade"] = true,
+				["imba_tusk_walrus_punch"] = true
+			}
+
+			if not exceptions[event_ability:GetAbilityName()] then
+				--Toggle abilities activated when turned on
+				--[[
+					Due being triggered on mana spent, this doesn't work properly with "lingering toggles",
+					like WD's Voodoo Restoration, that spend mana for a short while after being turned off.
+					For these, Damage will be applied if you toggle it OFF (silence will apply properly on
+					toggled ON only), only the damage is bugged.
+				--]]
+				if event_ability:IsToggle() and event_ability:GetToggleState() then
+					return nil
+				end
+
+				local damage_table = {
+					victim = target,
+					attacker = caster,
+					damage = ability:GetSpecialValueFor("damage"),
+					damage_type = ability:GetAbilityDamageType(),
+					ability = ability
+				}
+
+				ApplyDamage( damage_table )
+				target_modifier.damage_applied = true
+			end
+		end
+	end
+end
+
+-- Special case for damage applied if nothing is cast
+-- This is basically specifically to fix buggy interaction with WD's Voodoo Restoration, so damage isn't applied twice
+-- when you toggle the ability off (since it won't trigger the silence in that case)
+function LastWordDamageNoCast( keys )
+	local caster = keys.caster
+	local target = keys.target
+	local ability = keys.ability
+	local modifier = keys.modifier
+
+	local target_modifier = target:FindModifierByName(modifier)
+	
+	if target_modifier and target_modifier.damage_applied == nil then
+		local damage_table = {
+			victim = target,
+			attacker = caster,
+			damage = ability:GetSpecialValueFor("damage"),
+			damage_type = ability:GetAbilityDamageType(),
+			ability = ability
+		}
+
+		ApplyDamage( damage_table )
+		target_modifier.damage_applied = true
+	end
+end
+
+function LastWordDebuff( keys )
+	local caster = keys.caster
+	local target = keys.unit
+	local ability = keys.ability
+	local event_ability = keys.event_ability
+	local modifier = keys.modifier
+	local silence_modifier = keys.silence_modifier
+
+	local target_modifier = target:FindModifierByName(modifier)
+
+	if target_modifier and ( not event_ability:IsItem() ) then
+		-- Only extend duration of Toggle abilities when they are turned on
+		-- OnAbilityExecuted is ran before the toggle completes, so 'true' = we are about to turn it off
+		if event_ability:IsToggle() and event_ability:GetToggleState() then
+			return nil
+		end
+
+		-- We'll handle channeling at the end of it, so extend it indefinitely (unless last word was applied during channeling - this is consistent with vanilla Dota 2)
+		if event_ability:GetChannelTime() > 0 and target_modifier.channeling_handled == nil then
+			target_modifier:SetDuration( -1 , true )
+			target_modifier:StartIntervalThink( -1 )
+			target_modifier.channeling_handled = true
+			return nil
+		end
+
+		local sound = keys.sound
+		local damage_sound = keys.damage_sound
+
+		StopSoundEvent(sound, target)
+		target_modifier:Destroy()
+
+		ability:ApplyDataDrivenModifier(caster, target, silence_modifier, nil)
+		target:EmitSound(damage_sound)
+	end
+end
+
+function GlobalSilenceCast( keys )
+	local caster = keys.caster
+	local target = keys.target
+	local ability = keys.ability
+	local curse_name = keys.curse_name
+	local curse_modifier = keys.curse_modifier
+	local silence_modifier = keys.silence_modifier
+
+	-- Needs to be applied via LUA because if modifier IsPurgable in data-driven definition,
+	-- it won't be applied through "ApplyModifier"
+	ability:ApplyDataDrivenModifier(caster, target, silence_modifier, nil)
+
+	if caster:HasScepter() then
+		local curse_ability = caster:FindAbilityByName(curse_name)
+		if curse_ability and curse_ability:GetLevel() > 0 then
+			target:AddNewModifier(caster, curse_ability, curse_modifier, nil)
+		end
+	end
+end

--- a/game/dota_addons/dota_imba/scripts/vscripts/modifier/modifier_imba_arcane_curse_debuff.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/modifier/modifier_imba_arcane_curse_debuff.lua
@@ -1,0 +1,88 @@
+modifier_imba_arcane_curse_debuff = class({})
+
+function modifier_imba_arcane_curse_debuff:OnCreated( kv )
+	self.tick_rate = self:GetAbility():GetSpecialValueFor("tick_rate")
+	self.curse_slow = self:GetAbility():GetSpecialValueFor("curse_slow")
+	self.curse_damage = self:GetAbility():GetSpecialValueFor("damage_per_second")
+	self.penalty_duration = self:GetAbility():GetSpecialValueFor("penalty_duration")
+	self.parent = self:GetParent()
+
+	if IsServer() then
+		self:SetDuration( self:GetAbility():GetSpecialValueFor("base_duration"), true )
+		self:StartIntervalThink( self.tick_rate )
+	end
+end
+
+--Various Get's for attributes and effects
+function modifier_imba_arcane_curse_debuff:GetAttributes()
+	return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
+function modifier_imba_arcane_curse_debuff:GetEffectName()
+	return "particles/units/heroes/hero_silencer/silencer_curse.vpcf"
+end
+
+function modifier_imba_arcane_curse_debuff:GetEffectAttachType()
+	return PATTACH_OVERHEAD_FOLLOW
+end
+
+function modifier_imba_arcane_curse_debuff:GetTexture()
+	return "silencer_curse_of_the_silent"
+end
+
+function modifier_imba_arcane_curse_debuff:IsPurgable()
+	return true
+end
+
+function modifier_imba_arcane_curse_debuff:IsDebuff()
+	return true
+end
+
+function modifier_imba_arcane_curse_debuff:OnIntervalThink()
+	if IsServer() then
+		local target = self.parent
+		if target:IsSilenced() then
+			self:SetDuration( self:GetRemainingTime() + self.tick_rate, true )
+		else
+			local damage_per_tick = self.curse_damage * self.tick_rate
+
+			local damage_table = {
+				victim = target,
+				attacker = self:GetCaster(),
+				damage = damage_per_tick,
+				damage_type = self:GetAbility():GetAbilityDamageType(),
+				ability = self:GetAbility()
+			}
+
+			ApplyDamage( damage_table )
+		end
+	end
+end
+
+function modifier_imba_arcane_curse_debuff:DeclareFunctions()
+	local funcs = {
+		MODIFIER_EVENT_ON_ABILITY_EXECUTED,
+		MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE,
+	}
+ 
+	return funcs
+end
+
+function modifier_imba_arcane_curse_debuff:OnAbilityExecuted( params )
+	if IsServer() then
+		if ( not params.ability:IsItem() ) and ( params.unit == self.parent ) then
+			-- Only extend duration of Toggle abilities when they are turned on
+			-- OnAbilityExecuted is ran before the toggle completes, so 'true' = we are about to turn it off
+			if params.ability:IsToggle() and params.ability:GetToggleState() then
+				return
+			end
+			-- The main reason this is a LUA script...so I don't have to do black magic to extend every individual
+			-- curse modifier, in case we have multiple of them (since they stack)
+			self:SetDuration( self:GetRemainingTime() + self.penalty_duration, true )
+		end
+	end
+end
+
+function modifier_imba_arcane_curse_debuff:GetModifierMoveSpeedBonus_Percentage( params )
+	return self.curse_slow
+end

--- a/game/dota_addons/dota_imba/scripts/vscripts/modifier/modifier_imba_silencer_int_steal.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/modifier/modifier_imba_silencer_int_steal.lua
@@ -1,0 +1,79 @@
+modifier_imba_silencer_int_steal = class({})
+
+function modifier_imba_silencer_int_steal:OnCreated( kv )
+	self.steal_range = kv.steal_range or 925
+	self.steal_amount = kv.steal_amount or 2
+
+	if IsServer() then
+		self.parent = self:GetParent()
+		self:SetStackCount( self:GetStackCount() )
+		self.parent:CalculateStatBonus()
+	end
+end
+
+-- Manta Meta a possibility
+function modifier_imba_silencer_int_steal:AllowIllusionDuplicate()
+	return false
+end
+
+function modifier_imba_silencer_int_steal:RemoveOnDeath()
+	return false
+end
+
+function modifier_imba_silencer_int_steal:GetAttributes()
+	return MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE + MODIFIER_ATTRIBUTE_PERMANENT
+end
+
+function modifier_imba_silencer_int_steal:GetTexture()
+    return "silencer_glaives_of_wisdom"
+end
+
+function modifier_imba_silencer_int_steal:IsPurgeable()
+	return false
+end
+
+function modifier_imba_silencer_int_steal:DeclareFunctions()
+	local funcs = {
+		MODIFIER_EVENT_ON_DEATH,
+	}
+ 
+	return funcs
+end
+
+function modifier_imba_silencer_int_steal:OnDeath( params )
+	if IsServer() then
+		if self.parent == nil then
+			self.parent = self:GetParent()
+		end
+
+		if params.unit:IsRealHero() and ( params.unit ~= self.parent ) and ( params.unit:GetTeam() ~= self.parent:GetTeam() ) then
+			local distance = ( self.parent:GetAbsOrigin() - params.unit:GetAbsOrigin() ):Length2D()
+			if ( distance <= self.steal_range ) or ( params.attacker == self.parent ) then
+				-- This is totally a reference
+				local enemy_intelligence = params.unit:GetBaseIntellect()
+				local enemy_intelligence_taken = 0
+				if enemy_intelligence > 1 then
+					if ( (enemy_intelligence - self.steal_amount) >= 1 ) then
+						enemy_intelligence_taken = self.steal_amount
+					else
+						enemy_intelligence_taken = -(1 - enemy_intelligence)
+					end
+					params.unit:SetBaseIntellect( enemy_intelligence - enemy_intelligence_taken )
+					params.unit:CalculateStatBonus()
+
+					self.parent:SetBaseIntellect(self.parent:GetBaseIntellect() + enemy_intelligence_taken)
+					self:SetStackCount(self:GetStackCount() + enemy_intelligence_taken)
+					self.parent:CalculateStatBonus()
+
+					-- Copied from https://moddota.com/forums/discussion/1156/modifying-silencers-int-steal
+					local life_time = 2.0
+                    local digits = string.len( math.floor( enemy_intelligence_taken ) ) + 1
+                    local numParticle = ParticleManager:CreateParticle( "particles/msg_fx/msg_miss.vpcf", PATTACH_OVERHEAD_FOLLOW, self.parent )
+                    ParticleManager:SetParticleControl( numParticle, 1, Vector( 10, enemy_intelligence_taken, 0 ) )
+                    ParticleManager:SetParticleControl( numParticle, 2, Vector( life_time, digits, 0 ) )
+                    ParticleManager:SetParticleControl( numParticle, 3, Vector( 100, 100, 255 ) )
+				end
+			end
+		end
+	end
+end


### PR DESCRIPTION
Dota 2 Silencer with proper interactions with IMBA abilities (Arcane Curse/Last Word);

Includes English skill descriptions...I might add the other languages, since it's all copy paste. But not sure if it's worth it, considering that I do want to IMBA'fy Silencer as soon as it's cleared to do so.

This was all done as part of a personal initiative to get Silencer into IMBA, as in my opinion, he will drastically alter the landscape of 10v10's (that and I like coding and felt like learning how this is done with Dota 2 Custom Games).

**Feel free to contact me on Discord or leave a message here if there are any issues/additions/changes that you wish me to resolve.**
**I have done full ability tests with only 3-4 heroes (WD, Enigma, Puck, Axe, Necro too, actually), but I can't think of any kind of errant ability that stands out as potentially broken due to this.**

## Changes to hero and skills
* Arcane Curse/Int Steal aura are unchanged in values

### Hero
* 3 intelligence gain per level
* 1.5 BAT

### Glaives of Wisdom intelligence to damage changes
* Vanilla : 35%/50%/65%/80%
* Lazy IMBA : 45%/70%/95%/120%

### Global Silence
* CD reduced from 130 to 120/110/100
* Duration increased from 4/5/6 to 5/7/9
* Cast point decreased from 0.3 to 0.2

**Differences from vanilla:**
* **Last Word** : applies it's damage **before** the cast is done (Pugna Ward Zap style) - this change was coordinated with Firetoad;
* **Arcane Curse**/**Last Word** : applies the duration extension and silence (respectively) for **toggleable spells when turned ON** - change coordinated with Firetoad; (Examples include, Necro's Death Pulse being Toggle ON);

**Bugs:**
* As seen with the Enigma fix, now that the unit can die before casting something, there is a possibility of lua errors;
* Witch Doctor's Voodoo Restoration receives damage after you toggle it off (due to it lingering and spending mana shortly after being turned off).

**Weird interactions:**
* Puck is still the ultimate enigma as his Phase Shift seems to be the only channeling spell in the game that DOESN'T trigger "OnAbilityEndChannel" event, unlike things like Black Hole/WD's ult.