### PR TITLE
Invokers Quas/Wex/Exort don't trigger Arcane Curse

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_silencer/imba_arcane_curse.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_silencer/imba_arcane_curse.lua
@@ -129,12 +129,18 @@ end
 
 function modifier_imba_arcane_curse_debuff:OnAbilityExecuted( params )
 	if IsServer() then
-		if ( not params.ability:IsItem() ) and ( params.unit == self.parent ) then
+		local exception = {
+			["invoker_quas"] = true,
+			["invoker_wex"] = true,
+			["invoker_exort"] = true,
+		}
+		if ( not params.ability:IsItem() ) and ( params.unit == self.parent ) and ( not exception[params.ability:GetName()] ) then
 			-- Only extend duration of Toggle abilities when they are turned on
 			-- OnAbilityExecuted is ran before the toggle completes, so 'true' = we are about to turn it off
 			if params.ability:IsToggle() and params.ability:GetToggleState() then
 				return
 			end
+
 			self:SetDuration( self:GetRemainingTime() + self.penalty_duration, true )
 			self:IncrementStackCount()
 		end


### PR DESCRIPTION
Fixes that one Silencer/Invoker interaction thing.