### PR TITLE
Fix players possibly getting 1 extra ability point

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero_selection.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero_selection.lua
@@ -447,7 +447,7 @@ function HeroSelection:AssignHero(player_id, hero_name)
 		if HERO_STARTING_LEVEL > 1 then
 			Timers:CreateTimer(1, function()
 				hero:AddExperience(XP_PER_LEVEL_TABLE[HERO_STARTING_LEVEL], DOTA_ModifyXP_CreepKill, false, true)
-				hero:SetAbilityPoints(HERO_STARTING_LEVEL)
+				hero:SetAbilityPoints(hero:GetAbilityPoints() + HERO_STARTING_LEVEL - 1)
 			end)
 		end
 


### PR DESCRIPTION
Since setting of unspent ability points is done after a short delay, players can abuse the system by adding skill points before we set the unspent ability points.