### PR TITLE
Fix perma echo sabre bug

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/items/item_echo_sabre.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/items/item_echo_sabre.lua
@@ -9,7 +9,7 @@ function EchoSabreStart( keys )
 	local modifier_double = keys.modifier_double
 
 	-- If a higher-level echo sabre version is present, or the item is in cooldown, do nothing
-	if caster:HasModifier("modifier_item_imba_reverb_rapier_unique") or not ability:IsCooldownReady() then
+	if caster:HasModifier("modifier_item_imba_reverb_rapier_unique") or not ability:IsCooldownReady() or caster:HasModifier(modifier_double) then
 		return nil
 	end
 


### PR DESCRIPTION
Reproducible:

1. Pick tiny, buy echo sabre and refresher orb
2. Attack enemy
3. Use refresher orb just before he swings his hand (time critical)
4. Perma lowered BAT

Due to lowering BAT twice before it is increased.
It is possible to lower BAT further by performing it again and again