### PR TITLE
Bugfix for Silencer

### DIFF
--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -21321,7 +21321,7 @@
 		"BaseClass"							"ability_lua"
 		"ScriptFile"						"hero/hero_silencer/imba_glaives_of_wisdom"
 
-		"AbilityBehavior"					"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityBehavior"					"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
 		"AbilityUnitTargetTeam"				"DOTA_UNIT_TARGET_TEAM_ENEMY"
 		"AbilityUnitTargetType"				"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
 		"AbilityUnitDamageType"				"DAMAGE_TYPE_PURE"

--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_silencer/imba_glaives_of_wisdom.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_silencer/imba_glaives_of_wisdom.lua
@@ -182,7 +182,7 @@ function modifier_imba_silencer_glaives_of_wisdom:OnAttackLanded(keys)
 				EmitSoundOn(self.sound_hit, target)
 			end
 		end
-	end	
+	end
 end
 
 function modifier_imba_silencer_glaives_of_wisdom:OnOrder(keys)

--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_silencer/imba_global_silence.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_silencer/imba_global_silence.lua
@@ -13,7 +13,7 @@ function imba_silencer_global_silence:OnSpellStart()
 			if curse_ability and curse_ability:IsTrained() then
 				enemy:AddNewModifier(caster, curse_ability, "modifier_imba_arcane_curse_debuff", {duration = self:GetDuration()})
 			end
-			EmitSoundOn("Hero_Silencer.GlobalSilence.Effect", enemy)
+			EmitSoundOnClient("Hero_Silencer.GlobalSilence.Effect", enemy:GetPlayerOwner())
 		end
 	end
 end


### PR DESCRIPTION
Refer to issue #153 

* Global Silence now plays the target sound using `EmitSoundOnClient`, rather than `EmitSoundOn`. Hopefully, no more speakers/headphones/users will be hurt.
* **Couldn't locally reproduce Glaive's sound (either castsound or hitsound) looping in the middle of the map**, remains unfixed.