### PR TITLE
Fixes Riki's Blink Strike (again)

### DIFF
--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -18959,19 +18959,19 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"full_cast_range"		"800 1400 2000 2000 2000 2000 2000"	// max range (+600 per jump)
+				"full_cast_range"		"700 1400 2100 2100 2100 2100 2100"	// max range (+700 per jump)
 			}
 
 			"05"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"no_jump_cast_range"	"800"
+				"no_jump_cast_range"	"700"
 			}
 
 			"06"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"jump_range"			"600"
+				"jump_range"			"700"
 			}
 
 			"07"


### PR DESCRIPTION
To achieve consistency and not have the range indicator be weird and stuff, I've made the following changes:
* No jump cast range lowered from 800 -> 700
* Jump range increased from 600 -> 700

Moved the jump/range checks to OnAbilityPhaseStart, so Riki attempts to move to attack the targeted unit, if it cannot be reached though the ability cast.