### PR TITLE
Fixes Enigma's Demonic Conversion being castable on heroes

### DIFF
--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -8226,7 +8226,7 @@
 		"BaseClass"						"ability_lua"
 		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
 		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_BOTH"
-		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_BASIC"
 		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS"
 		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_NO"
 		"FightRecapLevel"				"1"


### PR DESCRIPTION
...without the talent.

This is done by removing the DOTA_UNIT_TARGET_HERO from AbilityUnitTargetType, so it fails the check by default (without the talent). This can be done in a different way, mind you, this is just the simplest.