### PR TITLE
Fixes AM's Mana Void not applying a ministun

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_antimage.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_antimage.lua
@@ -508,7 +508,7 @@ function imba_antimage_mana_void:OnSpellStart()
 		local target = self:GetCursorTarget()
 		local ability = self
 		local scepter = caster:HasScepter()
-		local modifier_ministun = "modifier_imba_mana_void_stunned"
+		local modifier_ministun = "modifier_mana_void_stunned"
 		
 		-- Parameters
 		local damage_per_mana = ability:GetSpecialValueFor("mana_void_damage_per_mana")


### PR DESCRIPTION
The stun modifier's name was changed during the standardization thing, but the string variable was not updated.