### PR TITLE
Fix Necrolyte Reapers Scythe/Tenacity

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_necrolyte.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_necrolyte.lua
@@ -758,7 +758,7 @@ function imba_necrolyte_reapers_scythe:IsHiddenWhenStolen()
 end
 
 modifier_imba_reapers_scythe = modifier_imba_reapers_scythe or class({})
-
+function modifier_imba_reapers_scythe:IgnoreTenacity() return true end
 function modifier_imba_reapers_scythe:OnCreated( params )
 	if IsServer() then
 		local caster = self:GetCaster()


### PR DESCRIPTION
Added IgnoreTenacity flag to Reapers Scythe modifier to ensure timer and stun_duration align. Tested locally and the ability works as intended versus Tenacity now.