### PR TITLE
Update flyout scoreboard again to semi-unfix previous hack which has been solved by valve

### DIFF
--- a/content/dota_addons/dota_imba/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/dota_addons/dota_imba/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -23,8 +23,7 @@
 	//GameUI.SetDefaultUIEnabled( DotaDefaultUIElement_t.DOTA_DEFAULT_UI_TOP_BAR_BACKGROUND, false );			//Top-left menu buttons in the HUD.
 
 	GameUI.SetDefaultUIEnabled( DotaDefaultUIElement_t.DOTA_DEFAULT_UI_TOP_HEROES, false );						//Heroes and team score at the top of the HUD.
-	//28-05-17 valve bug: scoreboard hotkey does not work when we disable flyout scoreboard, hence we will have to manually hide it ourselves
-    GameUI.SetDefaultUIEnabled( DotaDefaultUIElement_t.DOTA_DEFAULT_UI_FLYOUT_SCOREBOARD, true );				//Lefthand flyout scoreboard.
+    GameUI.SetDefaultUIEnabled( DotaDefaultUIElement_t.DOTA_DEFAULT_UI_FLYOUT_SCOREBOARD, false );				//Lefthand flyout scoreboard.
 	GameUI.SetDefaultUIEnabled( DotaDefaultUIElement_t.DOTA_DEFAULT_UI_HERO_SELECTION_TEAMS, false );			//Hero selection Radiant and Dire player lists.
 	GameUI.SetDefaultUIEnabled( DotaDefaultUIElement_t.DOTA_DEFAULT_UI_HERO_SELECTION_GAME_NAME, false );		//Hero selection game mode name display.
 	GameUI.SetDefaultUIEnabled( DotaDefaultUIElement_t.DOTA_DEFAULT_UI_HERO_SELECTION_CLOCK, false );			//Hero selection clock.

--- a/content/dota_addons/dota_imba/panorama/scripts/custom_game/multiteam_flyout_scoreboard.js
+++ b/content/dota_addons/dota_imba/panorama/scripts/custom_game/multiteam_flyout_scoreboard.js
@@ -1,32 +1,27 @@
 "use strict";
 
 var g_ScoreboardHandle = null;
+var g_flyoutUpdateTimer = null;
+
+function UpdateFlyoutScoreboard()
+{
+    ScoreboardUpdater_SetScoreboardActive( g_ScoreboardHandle, true );
+    g_flyoutUpdateTimer = $.Schedule( 0.2, UpdateFlyoutScoreboard );
+}
 
 function SetFlyoutScoreboardVisible( bVisible )
 {
 	$.GetContextPanel().SetHasClass( "flyout_scoreboard_visible", bVisible );
-	if ( bVisible )
-	{
-		ScoreboardUpdater_SetScoreboardActive( g_ScoreboardHandle, true );
-	}
-	else
-	{
-		ScoreboardUpdater_SetScoreboardActive( g_ScoreboardHandle, false );
-	}
-}
-
-function HideDotaOriginalScoreboard(){
-    var rootUI = $.GetContextPanel();
-    while(rootUI.id != "Hud" && rootUI.GetParent() != null){
-        rootUI = rootUI.GetParent();
+    if( bVisible ){
+        UpdateFlyoutScoreboard();
+    }else{
+        ScoreboardUpdater_SetScoreboardActive( g_ScoreboardHandle, false );
+        if( g_flyoutUpdateTimer )
+        {
+            $.CancelScheduled(g_flyoutUpdateTimer);
+            g_flyoutUpdateTimer = null;
+        }
     }
-
-    //Do not delete original scoreboard, it will cause unwanted crashes
-    var originalScoreboard = rootUI.FindChildTraverse("scoreboard");
-    var children = originalScoreboard.Children();
-    $.Each(children, function(child){
-        child.style.visibility = "collapse";
-    });
 }
 
 (function()
@@ -43,6 +38,4 @@ function HideDotaOriginalScoreboard(){
 	SetFlyoutScoreboardVisible( false );
 
 	$.RegisterEventHandler( "DOTACustomUI_SetFlyoutScoreboardVisible", $.GetContextPanel(), SetFlyoutScoreboardVisible );
-
-    HideDotaOriginalScoreboard();
 })();


### PR DESCRIPTION
Valve has fixed the flyout scoreboard however it no longer spams `visible` when you hold onto the scoreboard hotkey. Hence an additional timer was added to solve it
(In my opinion the change is a better interaction)

There is no longer a need to hide the original scoreboard panels since they should no longer exist, hence it should help with the lag a bit