### PR TITLE
Abaddon rework

### DIFF
--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -3873,8 +3873,27 @@
 			"05"
 			{
 				"var_type"								"FIELD_FLOAT"
+				"mist_duration"							"2.0"
+			}
+			"06"
+			{
+				"var_type"								"FIELD_INTEGER"
+				"on_hit_damage"							"10 12 15 19 24 30 37 45"
+			}
+			"07"
+			{
+				"var_type"								"FIELD_INTEGER"
+				"damage_heal_pct"						"10 11 12 15 18 22 26 30"
+			}
+			"08"
+			{
+				"var_type"								"FIELD_FLOAT"
+				"shield_duration_extend"				"3.0"
+			}
+			"09"
+			{
+				"var_type"								"FIELD_FLOAT"
 				"cooldown"								"4.5"
-				"LinkedSpecialBonus"					"special_bonus_imba_abaddon_3"
 			}
 		}
 
@@ -3910,7 +3929,7 @@
 
 		// Time
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"								"12.0 10.0 8.0 6.0 5.5 5.0 4.5"
+		"AbilityCooldown"								"12.0 10.0 8.0 6.0 6.0 6.0 6.0"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -3925,13 +3944,11 @@
 			{
 				"var_type"								"FIELD_FLOAT"
 				"duration"								"15.0"
-				"LinkedSpecialBonus"					"special_bonus_imba_abaddon_2"
 			}
 			"02"
 			{
 				"var_type"								"FIELD_INTEGER"
 				"shield"								"110 140 170 200 225 250 275"
-				"LinkedSpecialBonus"					"special_bonus_imba_abaddon_5"
 			}
 			"03"
 			{
@@ -3942,7 +3959,6 @@
 			{
 				"var_type"								"FIELD_INTEGER"
 				"cast_range"							"500"
-				"LinkedSpecialBonus"					"special_bonus_imba_abaddon_1"
 			}
 		}
 
@@ -3966,7 +3982,6 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"BaseClass"										"ability_lua"
 		"ScriptFile"									"hero/hero_abaddon.lua"
-		"AbilityBehavior"								"DOTA_ABILITY_BEHAVIOR_PASSIVE"
 		"SpellImmunityType"								"SPELL_IMMUNITY_ENEMIES_YES"
 		"AbilityTextureName"							"abaddon_frostmourne"
 		"MaxLevel"										"7"
@@ -3999,13 +4014,11 @@
 			{
 				"var_type"								"FIELD_INTEGER"
 				"move_increase"							"15"
-				"LinkedSpecialBonus"					"special_bonus_imba_abaddon_4"
 			}
 			"06"
 			{
 				"var_type"								"FIELD_INTEGER"
 				"attack_increase"						"10 20 30 40 40 40 40"
-				"LinkedSpecialBonus"					"special_bonus_imba_abaddon_4"
 			}
 			"07"
 			{
@@ -4023,7 +4036,7 @@
 	}
 
 	//=================================================================================================================
-	// Abaddon's Over Channel
+	// Abaddon's Overchannel
 	//=================================================================================================================
 	"imba_abaddon_over_channel"
 	{
@@ -4031,9 +4044,11 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"BaseClass"										"ability_lua"
 		"ScriptFile"									"hero/hero_abaddon.lua"
-		"AbilityBehavior"								"DOTA_ABILITY_BEHAVIOR_TOGGLE | DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
+		"AbilityBehavior"								"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
 		"AbilityTextureName"							"custom/abaddon_over_channel"
 		"MaxLevel"										"7"
+
+		"AbilityCooldown"								"3.0"
 
 		// Special
 		//-------------------------------------------------------------------------------------------------------------
@@ -4042,7 +4057,17 @@
 			"01"
 			{
 				"var_type"								"FIELD_INTEGER"
-				"extra_dmg"								"90 125 160 195 230 265 300 "
+				"extra_dmg"								"90 125 160 195 230 265 300"
+			}
+			"02"
+			{
+				"var_type"								"FIELD_FLOAT"
+				"extra_mist_duration"					"2.0"
+			}
+			"03"
+			{
+				"var_type"								"FIELD_FLOAT"
+				"extra_shield_health"					"75"
 			}
 		}
 
@@ -4093,7 +4118,6 @@
 			{
 				"var_type"								"FIELD_FLOAT"
 				"duration"								"4.0 5.0 6.0 6.5 7.0 7.5"
-				"LinkedSpecialBonus"					"special_bonus_imba_abaddon_7"
 			}
 			"03"
 			{
@@ -4104,7 +4128,6 @@
 			{
 				"var_type"								"FIELD_INTEGER"
 				"redirect_range"						"900"
-				"LinkedSpecialBonus"					"special_bonus_imba_abaddon_8"
 			}
 		}
 
@@ -4119,7 +4142,7 @@
 	}
 
 	//=================================================================================================================
-	// Abaddon Talent 1 (Level 10): +150 Aphotic Shield cast range
+	// Abaddon Talent 1 (Level 10): When the shield breaks, applies Mist Coil to all allies and enemies within 350 radius
 	//=================================================================================================================
 	"special_bonus_imba_abaddon_1"
 	{
@@ -4131,7 +4154,7 @@
 
 		"LinkedAbility"
 		{
-			"01" 	"imba_abaddon_aphotic_shield"			
+			"01" 	"imba_abaddon_mist_coil"			
 		}
 
 		// Special
@@ -4141,13 +4164,13 @@
 			"01"
 			{
 				"var_type"					"FIELD_INTEGER"
-				"value"						"150"
+				"value"						"350"
 			}
 		}
 	}
 
 	//=================================================================================================================
-	// Abaddon Talent 2 (Level 10): +45sec duration on Aphotic Shield
+	// Abaddon Talent 2 (Level 10): Consecutives hits of Curse of Avernus refreshes the buff/debuff and increases the duration of the buff/debuff by 1 second.
 	//=================================================================================================================
 	"special_bonus_imba_abaddon_2"
 	{
@@ -4159,7 +4182,7 @@
 
 		"LinkedAbility"
 		{
-			"01" 	"imba_abaddon_aphotic_shield"			
+			"01" 	"imba_abaddon_curse_of_avernus"			
 		}
 		    
 
@@ -4170,13 +4193,13 @@
 			"01"
 			{
 				"var_type"					"FIELD_FLOAT"
-				"value"						"45.0"
+				"value"						"1.0"
 			}
 		}
 	}
 
 	//=================================================================================================================
-	// Abaddon Talent 3 (Level 20): -1.5sec cooldown on Mist Coil
+	// Abaddon Talent 3 (Level 20): During the first second of Aphotic Shield, it absorbs all damage done to it and adds it to it's health/damage.
 	//=================================================================================================================
 	"special_bonus_imba_abaddon_3"
 	{
@@ -4188,7 +4211,7 @@
 
 		"LinkedAbility"
 		{
-			"01"	 "imba_abaddon_mist_coil"
+			"01"	 "imba_abaddon_aphotic_shield"
 		}
 
 		// Special
@@ -4198,13 +4221,13 @@
 			"01"
 			{
 				"var_type"					"FIELD_FLOAT"
-				"value"						"-1.5"
+				"value"						"1.0"
 			}
 		}
 	}
 
 	//=================================================================================================================
-	// Abaddon Talent 4 (Level 20): +5% move speed/+30 attack speed on Curse of Avernus
+	// Abaddon Talent 4 (Level 20): Curse of Avernus can now be activated to sacrifice a 10% of your current health, and deal it as extra damage on the next attack. Has a 8 seconds cooldown.
 	//=================================================================================================================
 	"special_bonus_imba_abaddon_4"
 	{
@@ -4226,18 +4249,23 @@
 			"01"
 			{
 				"var_type"					"FIELD_INTEGER"
-				"attack_increase"			"30"
+				"active_cooldown"			"8"
 			}
 			"02"
 			{
 				"var_type"					"FIELD_INTEGER"
-				"move_increase"				"5"
+				"health_cost_pct"			"10"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"health_to_damage_ratio"	"1"
 			}
 		}
 	}
 
 	//=================================================================================================================
-	// Abaddon Talent 5 (Level 30): +200 shielding on Aphotic Shield
+	// Abaddon Talent 5 (Level 30): Curse of Avernus Abbadon buff now apply as an aura around him in 900 AoE, affecting all allies in range.
 	//=================================================================================================================
 	"special_bonus_imba_abaddon_5"
 	{
@@ -4249,7 +4277,7 @@
 
 		"LinkedAbility"
 		{
-			"01" 	"imba_abaddon_aphotic_shield"			
+			"01" 	"imba_abaddon_curse_of_avernus"			
 		}
 
 		// Special
@@ -4259,7 +4287,7 @@
 			"01"
 			{
 				"var_type"					"FIELD_INTEGER"
-				"value"						"200"
+				"value"						"900"
 			}
 		}
 	}
@@ -4293,7 +4321,7 @@
 	}
 
 	//=================================================================================================================
-	// Abaddon Talent 7 (Level 40): +1sec duration on Borrowed Time
+	// Abaddon Talent 7 (Level 40): Borrowed Time Strong Purges all allies in 900 AoE on cast.
 	//=================================================================================================================
 	"special_bonus_imba_abaddon_7"
 	{
@@ -4312,7 +4340,7 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilitySpecial"
 		{
-			"01"
+			"01" //Unused
 			{
 				"var_type"					"FIELD_FLOAT"
 				"value"						"1.0"
@@ -4321,7 +4349,7 @@
 	}
 
 	//=================================================================================================================
-	// Abaddon Talent 8 (Level 40): +300 aura range on Borrowed Time
+	// Abaddon Talent 8 (Level 40): Heals that heal above maximum health threshold during Borrowed Time grants a mist shield (25% ratio) that is released after Borrowed Time expires for 5 seconds, healing Abaddon.
 	//=================================================================================================================
 	"special_bonus_imba_abaddon_8"
 	{
@@ -4343,7 +4371,12 @@
 			"01"
 			{
 				"var_type"					"FIELD_INTEGER"
-				"value"						"300"
+				"ratio_pct"					"25"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"mist_duration"				"5"
 			}
 		}
 	}

--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -4071,6 +4071,11 @@
 				"var_type"								"FIELD_FLOAT"
 				"extra_shield_health"					"75"
 			}
+			"04"
+			{
+				"var_type"								"FIELD_FLOAT"
+				"curse_of_avernus_multiplier"			"2"
+			}
 		}
 
 		"precache"

--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -3981,6 +3981,8 @@
 		// General
 		//-------------------------------------------------------------------------------------------------------------
 		"BaseClass"										"ability_lua"
+		"AbilityUnitTargetType"							"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetTeam"							"DOTA_UNIT_TARGET_TEAM_ENEMY"
 		"ScriptFile"									"hero/hero_abaddon.lua"
 		"SpellImmunityType"								"SPELL_IMMUNITY_ENEMIES_YES"
 		"AbilityTextureName"							"abaddon_frostmourne"

--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -3895,6 +3895,11 @@
 				"var_type"								"FIELD_FLOAT"
 				"cooldown"								"4.5"
 			}
+			"10"
+			{
+				"var_type"								"FIELD_FLOAT"
+				"damage_threshold"						"50"
+			}
 		}
 
 		"precache"
@@ -4064,12 +4069,12 @@
 			"02"
 			{
 				"var_type"								"FIELD_FLOAT"
-				"extra_mist_duration"					"2.0"
+				"extra_shield_health"					"75"
 			}
 			"03"
 			{
 				"var_type"								"FIELD_FLOAT"
-				"extra_shield_health"					"75"
+				"extra_mist_duration"					"2.0"
 			}
 			"04"
 			{

--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_abaddon.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_abaddon.lua
@@ -288,11 +288,12 @@ end
 
 function modifier_imba_mist_coil_mist_enemy:OnCreated()
 	self.on_hit_damage = self:GetAbility():GetSpecialValueFor("on_hit_damage")
+	self.damage_threshold = self:GetAbility():GetSpecialValueFor("damage_threshold")
 	self.damage_type = DAMAGE_TYPE_MAGICAL
 end
 
 function modifier_imba_mist_coil_mist_enemy:OnTakeDamage(keys)
-	if keys.unit == self:GetParent() and keys.original_damage > 50 then
+	if keys.unit == self:GetParent() and keys.original_damage > self.damage_threshold then
 		ApplyDamage({victim = keys.unit, attacker = keys.attacker, damage = self.on_hit_damage, damage_type = self.damage_type})
 	end
 end

--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_abaddon.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_abaddon.lua
@@ -629,6 +629,7 @@ function imba_abaddon_curse_of_avernus:OnSpellStart()
 	if IsServer() then
 		self.curse_of_avernus_target = self:GetCursorTarget()
 		self:GetCaster():MoveToTargetToAttack(self.curse_of_avernus_target)
+		self:EndCooldown() --we enter cooldown OnAttack
 	end
 end
 
@@ -713,6 +714,13 @@ function modifier_imba_curse_of_avernus_passive:OnAttack(kv)
 
 		if kv.attacker == caster and self.ability:IsCooldownReady() and ( self.ability.curse_of_avernus_target or self.ability:GetAutoCastState() ) then
 			local health_lost = caster:GetHealth() * caster:FindTalentValue("special_bonus_imba_abaddon_4", "health_cost_pct") / 100
+
+			local over_channel_modifier = caster:FindModifierByName("modifier_over_channel_handler")
+			if over_channel_modifier then
+				-- if we have overchannel, double the health lost and damage (+50% Overchannel strength also applies multiplicatively, for maximum lols)
+				health_lost = health_lost * over_channel_modifier:GetAbility():GetSpecialValueFor("curse_of_avernus_multiplier") * (1 + caster:FindTalentValue("special_bonus_imba_abaddon_6"))
+				over_channel_modifier:Destroy()
+			end
 
 			self.damage = health_lost * caster:FindTalentValue("special_bonus_imba_abaddon_4", "health_to_damage_ratio")
 			self.ability.curse_of_avernus_target = kv.target

--- a/game/dota_addons/dota_imba/scripts/vscripts/internal/funcs.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/internal/funcs.lua
@@ -482,9 +482,10 @@ function CDOTA_BaseNPC:HasTalent(talentName)
 	return false
 end
 
-function CDOTA_BaseNPC:FindTalentValue(talentName)
+function CDOTA_BaseNPC:FindTalentValue(talentName, key)
 	if self:HasAbility(talentName) then
-		return self:FindAbilityByName(talentName):GetSpecialValueFor("value")
+		local value_name = key or "value"
+		return self:FindAbilityByName(talentName):GetSpecialValueFor(value_name)
 	end
 	return 0
 end

--- a/game/dota_addons/dota_imba/scripts/vscripts/libraries/client_util.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/libraries/client_util.lua
@@ -36,12 +36,13 @@ function C_DOTA_BaseNPC:HasTalent(talentName)
 	return false
 end
 
-function C_DOTA_BaseNPC:FindTalentValue(talentName)
+function C_DOTA_BaseNPC:FindTalentValue(talentName, key)
 	if self:HasModifier("modifier_"..talentName) then  
+		local value_name = key or "value"
 		local specialVal = AbilityKV[talentName]["AbilitySpecial"]
 		for l,m in pairs(specialVal) do
-			if m["value"] then
-				return m["value"]
+			if m[value_name] then
+				return m[value_name]
 			end
 		end
 	end    


### PR DESCRIPTION
closes #510 

**Skills/Talents only, no strings/tooltips done**

After this is merged `FindTalentValue` will now accept a optional key (`FindTalentValue("talent", "key")`) that will allow your talents to have multiple abilityspecial values (in my case, it was useful for Curse of Avernus active talent). If you don't pass the optional key, it defaults to "value".