### PR TITLE
Double Abaddons, what does it all mean?

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_abaddon.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_abaddon.lua
@@ -1131,7 +1131,10 @@ end
 
 function modifier_imba_borrowed_time_buff_hot_caster:GetAuraEntityReject(hEntity)
 	-- Do not apply aura to target
-	return hEntity == self:GetParent()
+	if hEntity == self:GetParent() or hEntity:HasModifier("modifier_imba_borrowed_time_buff_hot_caster") then
+		return true
+	end
+	return false
 end
 
 function modifier_imba_borrowed_time_buff_hot_caster:OnCreated()


### PR DESCRIPTION
Double Abaddons no longer crash games due to Borrowed Time overload