### PR TITLE
Fix to quill spray/nastle goo stacks not working

### DIFF
--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_override.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_override.txt
@@ -3720,6 +3720,7 @@
 			{
 				"var_type"				"FIELD_INTEGER"
 				"stack_limit"			"4 4 4 4 5 5 6"
+				"LinkedSpecialBonus"	"special_bonus_unique_bristleback"
 			}
 			"07"
 			{
@@ -3763,12 +3764,12 @@
 			{
 				"var_type"				"FIELD_INTEGER"
 				"quill_stack_damage"	"30 32 34 36 39 42 45"
+				"LinkedSpecialBonus"	"special_bonus_unique_bristleback_2"
 			}
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
 				"quill_stack_duration"	"14.0"
-				"LinkedSpecialBonus"	"special_bonus_unique_bristleback"
 			}
 			"05"
 			{


### PR DESCRIPTION
Fix to a bug where quill spray and nasal goo stacks wouldn't apply/grant any bonus damage.