### PR TITLE
Reworked Veil And many other bugfixes

### DIFF
--- a/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff.vpcf
+++ b/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff.vpcf
@@ -1,0 +1,58 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 0
+	m_BoundingBoxMin = [ -512.0, -512.0, -32.0 ]
+	m_BoundingBoxMax = [ 512.0, 512.0, 32.0 ]
+	m_flConstantRadius = 32.0
+	m_ConstantColor = [ 0, 0, 0, 255 ]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_SetControlPointPositions"
+			m_flOpStartFadeOutTime = 0.1
+			m_flOpEndFadeOutTime = 0.1
+			m_vecCP1Pos = [ 241.0, 114.0, 255.0 ]
+			m_nCP3 = 2
+			m_nCP4 = 2
+			m_bUseWorldLocation = true
+		},
+	]
+	m_Children = 
+	[
+		{
+			m_ChildRef = resource:"particles/item/veil_of_discord/veil_arcane_buff_a.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/item/veil_of_discord/veil_arcane_buff_b.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/item/veil_of_discord/veil_arcane_buff_c.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/item/veil_of_discord/veil_arcane_buff_d.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/item/veil_of_discord/veil_arcane_buff_e.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/item/veil_of_discord/veil_arcane_buff_f.vpcf"
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_a.vpcf
+++ b/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_a.vpcf
@@ -1,0 +1,50 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 1
+	m_flConstantRadius = 365.0
+	m_ConstantColor = [ 209, 0, 232, 255 ]
+	m_nConstantSequenceNumber = 1
+	m_nConstantSequenceNumber1 = 1
+	m_flMaxRecreationTime = -1.0
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderDeferredLight"
+			m_flAlphaScale = 24.0
+			m_flStartFalloff = 0.1
+			m_hTexture = resource:"materials/particle/particle_flares/particle_flare_001.vtex"
+			m_ColorScale = [ 255, 255, 255 ]
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_BasicMovement"
+			m_nOpEndCapState = 0
+		},
+		{
+			_class = "C_OP_OscillateScalarSimple"
+			m_Frequency = 5.0
+			m_Rate = 4.0
+			m_flOscMult = 1.8
+		},
+		{
+			_class = "C_OP_EndCapTimedDecay"
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_CreateWithinSphere"
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 1
+		},
+	]
+}

--- a/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_b.vpcf
+++ b/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_b.vpcf
@@ -1,0 +1,107 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 6
+	m_BoundingBoxMin = [ -512.0, -512.0, -32.0 ]
+	m_BoundingBoxMax = [ 512.0, 512.0, 32.0 ]
+	m_flConstantRadius = 48.0
+	m_bShouldSort = false
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_bAdditive = true
+			m_hTexture = resource:"materials/particle/particle_ring_wavy4.vtex"
+			m_nOrientationType = 2
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_FadeInSimple"
+		},
+		{
+			_class = "C_OP_FadeOutSimple"
+			m_flFadeOutTime = 0.35
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flBias = 0.85
+			m_flStartScale = 0.0
+		},
+		{
+			_class = "C_OP_ColorInterpolate"
+			m_ColorFade = [ 139, 0, 139, 255 ]
+		},
+		{
+			_class = "C_OP_EndCapTimedDecay"
+			m_flDecayTime = 0.125
+		},
+		{
+			_class = "C_OP_LerpEndCapScalar"
+			m_flOutput = 0.0
+			m_flLerpTime = 0.125
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 1.0
+			m_fLifetimeMin = 0.75
+		},
+		{
+			_class = "C_INIT_CreateWithinSphere"
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMax = [ 0.0, 0.0, 48.0 ]
+			m_OffsetMin = [ 0.0, 0.0, 48.0 ]
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+			m_bRandomlyFlipDirection = false
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMin = 64
+			m_nAlphaMax = 128
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 70.0
+			m_flRadiusMax = 80.0
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMin = [ 128, 0, 128, 255 ]
+			m_ColorMax = [ 148, 0, 211, 255 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmitRate = 5.0
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_c.vpcf
+++ b/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_c.vpcf
@@ -1,0 +1,112 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 10
+	m_BoundingBoxMin = [ -512.0, -512.0, -32.0 ]
+	m_BoundingBoxMax = [ 512.0, 512.0, 32.0 ]
+	m_flConstantRadius = 48.0
+	m_ConstantColor = [ 0, 66, 255, 255 ]
+	m_bShouldSort = false
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_bDisableZBuffering = true
+			m_flOverbrightFactor = 15.0
+			m_hTexture = resource:"materials/particle/lens_flare/lens_flare.vtex"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flBias = 0.85
+			m_flStartScale = 0.0
+		},
+		{
+			_class = "C_OP_FadeInSimple"
+			m_flFadeInTime = 0.5
+		},
+		{
+			_class = "C_OP_FadeOutSimple"
+			m_flFadeOutTime = 1.0
+		},
+		{
+			_class = "C_OP_EndCapTimedDecay"
+			m_flDecayTime = 0.125
+		},
+		{
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 7
+			m_flOutput = 0.0
+			m_flLerpTime = 0.125
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 2.0
+			m_fLifetimeMin = 1.5
+		},
+		{
+			_class = "C_INIT_CreateWithinSphere"
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMax = [ 0.0, 0.0, 48.0 ]
+			m_OffsetMin = [ 0.0, 0.0, 48.0 ]
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+			m_flDegreesMin = 73.0
+			m_flDegreesMax = 82.0
+			m_bRandomlyFlipDirection = false
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+		},
+		{
+			_class = "C_INIT_RandomSequence"
+			m_nSequenceMin = 1
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 128.0
+			m_flRadiusMax = 160.0
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMin = [ 218, 112, 214, 255 ]
+			m_ColorMax = [ 139, 0, 139, 255 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmitRate = 5.0
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_d.vpcf
+++ b/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_d.vpcf
@@ -1,0 +1,124 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 6
+	m_BoundingBoxMin = [ -512.0, -512.0, -32.0 ]
+	m_BoundingBoxMax = [ 512.0, 512.0, 32.0 ]
+	m_flConstantRadius = 48.0
+	m_bShouldSort = false
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_flOverbrightFactor = 4.0
+			m_hTexture = resource:"materials/particle/particle_ring_pulled.vtex"
+			m_nOrientationType = 2
+			VisibilityInputs = 
+			{
+				m_flCameraBias = -50.0
+			}
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flBias = 0.85
+			m_flStartScale = 0.0
+		},
+		{
+			_class = "C_OP_FadeInSimple"
+			m_flFadeInTime = 0.5
+		},
+		{
+			_class = "C_OP_FadeOutSimple"
+			m_flFadeOutTime = 1.0
+		},
+		{
+			_class = "C_OP_ColorInterpolate"
+			m_ColorFade = [ 46, 0, 255, 255 ]
+		},
+		{
+			_class = "C_OP_EndCapTimedDecay"
+			m_flDecayTime = 0.125
+		},
+		{
+			_class = "C_OP_LerpEndCapScalar"
+			m_flOutput = 0.0
+			m_flLerpTime = 0.125
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 2.0
+			m_fLifetimeMin = 1.5
+		},
+		{
+			_class = "C_INIT_CreateWithinSphere"
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMax = [ 0.0, 0.0, 48.0 ]
+			m_OffsetMin = [ 0.0, 0.0, 48.0 ]
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+			m_flDegreesMin = 90.0
+			m_flDegreesMax = 90.0
+			m_bRandomlyFlipDirection = false
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMax = 128
+			m_nAlphaMin = 100
+		},
+		{
+			_class = "C_INIT_RandomSequence"
+			m_nSequenceMin = 1
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 85.0
+			m_flRadiusMax = 90.0
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMin = [ 238, 130, 238, 255 ]
+			m_ColorMax = [ 148, 0, 211, 255 ]
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+			m_nFieldOutput = 12
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmitRate = 3.0
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_e.vpcf
+++ b/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_e.vpcf
@@ -1,0 +1,122 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 24
+	m_BoundingBoxMin = [ -512.0, -512.0, -32.0 ]
+	m_BoundingBoxMax = [ 512.0, 512.0, 32.0 ]
+	m_flConstantRadius = 64.0
+	m_bShouldSort = false
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_flOverbrightFactor = 2.0
+			m_hTexture = resource:"materials/particle/particle_flares/aircraft_blue2.vtex"
+			m_bSaturateColorPreAlphaBlend = false
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_BasicMovement"
+			m_fDrag = 0.05
+			m_Gravity = [ 0.0, 0.0, 250.0 ]
+		},
+		{
+			_class = "C_OP_FadeInSimple"
+		},
+		{
+			_class = "C_OP_FadeOutSimple"
+			m_flFadeOutTime = 0.5
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flEndScale = 0.0
+			m_flBias = 0.25
+		},
+		{
+			_class = "C_OP_VectorNoise"
+			m_bAdditive = true
+			m_vecOutputMax = [ 2.0, 2.0, 2.0 ]
+			m_vecOutputMin = [ -2.0, -2.0, -2.0 ]
+			m_nFieldOutput = 0
+			m_fl4NoiseScale = 0.5
+		},
+		{
+			_class = "C_OP_SpinUpdate"
+		},
+		{
+			_class = "C_OP_ColorInterpolate"
+			m_ColorFade = [ 15, 0, 77, 255 ]
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMin = 1.25
+			m_fLifetimeMax = 1.5
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMin = 200
+		},
+		{
+			_class = "C_INIT_CreateWithinSphere"
+			m_fRadiusMax = 10.0
+			m_fSpeedMin = 50.0
+			m_fSpeedMax = 75.0
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMin = [ 0.0, 0.0, 32.0 ]
+			m_OffsetMax = [ 0.0, 0.0, 32.0 ]
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMax = 80.0
+			m_flRadiusMin = 64.0
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMax = [ 138, 79, 255, 255 ]
+			m_ColorMin = [ 241, 114, 255, 255 ]
+		},
+		{
+			_class = "C_INIT_RandomRotationSpeed"
+			m_flDegreesMax = 120.0
+			m_flDegreesMin = 90.0
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmitRate = 16.0
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_f.vpcf
+++ b/content/dota_addons/dota_imba/particles/item/veil_of_discord/veil_arcane_buff_f.vpcf
@@ -1,0 +1,109 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 8
+	m_BoundingBoxMin = [ -512.0, -512.0, -32.0 ]
+	m_BoundingBoxMax = [ 512.0, 512.0, 32.0 ]
+	m_flConstantRadius = 48.0
+	m_bShouldSort = false
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_bGammaCorrectVertexColors = false
+			m_bSaturateColorPreAlphaBlend = false
+			m_bAdditive = true
+			m_bMod2X = true
+			m_flOverbrightFactor = 2.0
+			VisibilityInputs = 
+			{
+				m_flCameraBias = 30.0
+			}
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_FadeInSimple"
+			m_flFadeInTime = 0.5
+		},
+		{
+			_class = "C_OP_FadeOutSimple"
+			m_flFadeOutTime = 1.0
+		},
+		{
+			_class = "C_OP_EndCapTimedDecay"
+			m_flDecayTime = 0.125
+		},
+		{
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 7
+			m_flOutput = 0.0
+			m_flLerpTime = 0.125
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 2.0
+			m_fLifetimeMin = 1.5
+		},
+		{
+			_class = "C_INIT_CreateWithinSphere"
+			m_fRadiusMax = 8.0
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMax = [ 0.0, 0.0, 64.0 ]
+			m_OffsetMin = [ 0.0, 0.0, 48.0 ]
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+			m_flDegreesMin = 90.0
+			m_flDegreesMax = 90.0
+			m_bRandomlyFlipDirection = false
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMax = 128
+			m_nAlphaMin = 100
+		},
+		{
+			_class = "C_INIT_RandomSequence"
+			m_nSequenceMin = 1
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 30.0
+			m_flRadiusMax = 40.0
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmitRate = 4.0
+		},
+	]
+	m_ConstantColor = [ 0, 145, 255, 255 ]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -4057,7 +4057,7 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"BaseClass"										"ability_lua"
 		"ScriptFile"									"hero/hero_abaddon.lua"
-		"AbilityBehavior"								"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
+		"AbilityBehavior"								"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
 		"AbilityTextureName"							"custom/abaddon_over_channel"
 		"MaxLevel"										"7"
 

--- a/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_abilities_custom.txt
@@ -4857,8 +4857,9 @@
 		{
 			"01"
 			{
-				"var_type"					"FIELD_FLOAT"
-				"damage_per_burn"			"0.6"
+				"var_type"						"FIELD_FLOAT"
+				"damage_per_burn"				"0.6"
+				"CalculateSpellDamageTooltip"   "0"
 			}
 
 			"02"
@@ -4881,8 +4882,9 @@
 
 			"07"
 			{
-				"var_type"					"FIELD_INTEGER"
-				"max_mana_blast"			"5 5 5 5 10 15 20"
+				"var_type"						"FIELD_INTEGER"
+				"max_mana_blast"				"5 5 5 5 10 15 20"
+				"CalculateSpellDamageTooltip"   "1"
 			}
 
 			"08"
@@ -4902,6 +4904,9 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"BaseClass"						"ability_lua"
 		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
+		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_MAGICAL"
 		"FightRecapLevel"				"1"
 		"AbilityTextureName"			"antimage_blink"
 		"ScriptFile"					"hero/hero_antimage"
@@ -4944,8 +4949,9 @@
 
 			"03"
 			{
-				"var_type"					"FIELD_INTEGER"
-				"percent_damage"			"30"
+				"var_type"						"FIELD_INTEGER"
+				"percent_damage"				"30"
+				"CalculateSpellDamageTooltip"   "1"
 			}
 			
 			"04"

--- a/game/dota_addons/dota_imba/scripts/npc/npc_items_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_items_custom.txt
@@ -7491,11 +7491,12 @@
 		// General
 		//-------------------------------------------------------------------------------------------------------------
 		"ID"							"2101"
-		"BaseClass"						"item_datadriven"
+		"BaseClass"						"item_lua"
+		"ScriptFile"					"items/item_veil_of_discord.lua"
 		"AbilityTextureName" 			"custom/imba_veil_of_discord"
-		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
 		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
-		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_CREEP"
 
 		// Stats
 		//-------------------------------------------------------------------------------------------------------------
@@ -7520,12 +7521,17 @@
 			"01"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"aura_radius"			"900"
+				"bonus_int"				"14"
 			}
 			"02"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"aura_resist"			"-20"
+				"bonus_str"				"6"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"bonus_agi"				"6"
 			}
 			"03"
 			{
@@ -7540,107 +7546,46 @@
 			"05"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"bonus_int"				"14"
+				"bonus_attack_damage"	"6"
 			}
 			"06"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"debuff_duration"		"8"
+				"active_aoe"			"600"
 			}
 			"07"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"target_damage"			"100"
-				"CalculateSpellDamageTooltip"	"1"
+				"active_resis"			"-10"
 			}
-		}
-
-		"OnSpellStart"
-		{
-			"FireEffect"
+			"08"
 			{
-				"EffectName"			"particles/generic_gameplay/generic_manaburn.vpcf"
-				"EffectAttachType"		"follow_origin"
-				"Target"				"TARGET"
+				"var_type"				"FIELD_INTEGER"
+				"active_spell_power"	"10"
 			}
-
-			"FireSound"
+			"09"
 			{
-				"EffectName"			"DOTA_Item.VeilofDiscord.Activate"
-				"Target" 				"TARGET"
+				"var_type"				"FIELD_INTEGER"
+				"debuff_duration"		"8"
 			}
-
-			"ApplyModifier"
+			"10"
 			{
-				"ModifierName"			"modifier_item_imba_veil_of_discord_target_debuff"
-				"Target" 				"TARGET"
+				"var_type"				"FIELD_INTEGER"
+				"buff_duration"			"8"
 			}
-
-			"Damage"
+			"11"
 			{
-				"Target"				"TARGET"
-				"Type"					"DAMAGE_TYPE_MAGICAL"
-				"Damage"				"%target_damage"
+				"var_type"				"FIELD_INTEGER"
+				"aura_radius"			"900"
 			}
-		}
-
-		"Modifiers"
-		{
-			"modifier_item_imba_veil_of_discord"
+			"12"
 			{
-				"Passive"				"1"
-				"IsHidden"				"1"
-
-				"Attributes"			"MODIFIER_ATTRIBUTE_MULTIPLE | MODIFIER_ATTRIBUTE_PERMANENT"
-
-				"Properties"
-				{
-					"MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT"				"%bonus_health_regen"
-					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS"				"%bonus_armor"
-					"MODIFIER_PROPERTY_STATS_INTELLECT_BONUS"				"%bonus_int"
-				}
-			}
-
-			"modifier_item_imba_veil_of_discord_aura"
-			{
-				"Passive"				"1"
-				"IsHidden"				"1"
-
-				"Aura"          		"modifier_item_imba_veil_of_discord_aura_debuff"
-				"Aura_Radius"   		"%aura_radius"
-				"Aura_Teams"    		"DOTA_UNIT_TARGET_TEAM_ENEMY"
-				"Aura_Types"    		"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
-				"Aura_ApplyToCaster" 	"0"
-			}
-
-			"modifier_item_imba_veil_of_discord_aura_debuff"
-			{
-				"IsDebuff"				"1"
-
-				"Properties"
-				{
-					"MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS" 			"%aura_resist"
-				}
-			}
-
-			"modifier_item_imba_veil_of_discord_target_debuff"
-			{
-				"IsDebuff"				"1"
-				"IsPurgable"			"1"
-
-				"EffectName"			"particles/items2_fx/veil_of_discord_debuff.vpcf"
-				"EffectAttachType"		"follow_origin"
-
-				"Duration"				"%debuff_duration"
-
-				"Properties"
-				{
-					"MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS" 			"%aura_resist"
-				}
+				"var_type"				"FIELD_INTEGER"
+				"aura_resist"			"-25"
 			}
 		}
 	}
-
+	
 	//=================================================================================================================
 	// Recipe: Heaven's Halberd
 	//=================================================================================================================

--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_pugna.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_pugna.lua
@@ -825,6 +825,7 @@ function modifier_imba_nether_ward_degen:OnSpentMana(keys)
             "monkey_king_primal_spring",
             "monkey_king_wukongs_command",
 			"doom_doom",
+			"zuus_cloud",
         }
 
         -- Ignore items

--- a/game/dota_addons/dota_imba/scripts/vscripts/items/item_veil_of_discord.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/items/item_veil_of_discord.lua
@@ -1,0 +1,197 @@
+-- Author: Fudge
+
+------------------------------------
+------------ ACTIVE ----------------
+------------------------------------
+item_imba_veil_of_discord = item_imba_veil_of_discord or class({})
+LinkLuaModifier("modifier_veil_passive", "items/item_veil_of_discord.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_veil_aura", "items/item_veil_of_discord.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_veil_active_buff", "items/item_veil_of_discord.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_veil_active_debuff", "items/item_veil_of_discord.lua", LUA_MODIFIER_MOTION_NONE)
+
+function item_imba_veil_of_discord:OnSpellStart()
+    -- Ability properties
+    local caster        =   self:GetCaster()
+    local target_loc    =   self:GetCursorPosition()
+    local particle      =   "particles/items2_fx/veil_of_discord.vpcf"
+    -- Ability parameters
+    local radius            =   self:GetSpecialValueFor("active_aoe")
+    local buff_duration     =   self:GetSpecialValueFor("buff_duration")
+    local debuff_duration   =   self:GetSpecialValueFor("debuff_duration")
+
+    -- Emit the particle
+    local particle_fx = ParticleManager:CreateParticle(particle, PATTACH_ABSORIGIN, caster)
+    ParticleManager:SetParticleControl(particle_fx, 0, target_loc)
+    ParticleManager:SetParticleControl(particle_fx, 1, Vector(radius,1 ,1 ))
+    ParticleManager:ReleaseParticleIndex(particle_fx)
+
+    -- Find units around the target point
+    local units =   FindUnitsInRadius(caster:GetTeamNumber(),
+    target_loc,
+    nil,
+    radius,
+    DOTA_UNIT_TARGET_TEAM_BOTH,
+    DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_CREEP,
+    0,
+    FIND_ANY_ORDER,
+    false)
+
+    -- Iterate through the unit table and give each unit its respective modifier
+    for _,unit in pairs(units) do
+        -- Give allies a buff
+        if unit:GetTeamNumber() == caster:GetTeamNumber() then
+            unit:AddNewModifier(caster, self, "modifier_veil_active_buff", {duration = buff_duration})
+        else
+            -- Give enemies a debuff
+            unit:AddNewModifier(caster, self, "modifier_veil_active_debuff", {duration = debuff_duration})
+        end
+    end
+end
+
+function item_imba_veil_of_discord:GetAOERadius()
+    return self:GetSpecialValueFor("active_aoe")
+end
+
+function item_imba_veil_of_discord:GetIntrinsicModifierName()
+    return "modifier_veil_passive"
+end
+
+--- ACTIVE BUFF MODIFIER
+modifier_veil_active_buff = modifier_veil_active_buff or class({})
+
+-- Modifier properties
+function modifier_veil_active_buff:IsDebuff() return false end
+function modifier_veil_active_buff:IsHidden() return false end
+function modifier_veil_active_buff:IsPurgable() return true end
+
+function modifier_veil_active_buff:OnCreated()
+    self.spell_power    =   self:GetAbility():GetSpecialValueFor("active_spell_power")
+end
+
+function modifier_veil_active_buff:DeclareFunctions()
+    local funcs =   {
+        MODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE
+    }
+    return funcs
+end
+
+function modifier_veil_active_buff:GetModifierSpellAmplify_Percentage()
+    return self.spell_power
+end
+
+function modifier_veil_active_buff:GetEffectName()
+    return "particles/item/veil_of_discord/veil_arcane_buff.vpcf"
+end
+
+function modifier_veil_active_buff:GetEffectAttachType()
+    return PATTACH_ABSORIGIN_FOLLOW
+end
+
+--- ACTIVE DEBUFF MODIFIER
+modifier_veil_active_debuff = modifier_veil_active_debuff or class({})
+
+-- Modifier properties
+function modifier_veil_active_debuff:IsDebuff() return true end
+function modifier_veil_active_debuff:IsHidden() return false end
+function modifier_veil_active_debuff:IsPurgable() return true end
+
+function modifier_veil_active_debuff:OnCreated()
+    self.magic_resis    =   self:GetAbility():GetSpecialValueFor("active_resis")
+end
+function modifier_veil_active_debuff:DeclareFunctions()
+    local funcs =   {
+        MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS
+    }
+    return funcs
+end
+
+function modifier_veil_active_debuff:GetModifierMagicalResistanceBonus()
+    return self.magic_resis
+end
+
+function modifier_veil_active_debuff:GetEffectName()
+    return "particles/items2_fx/veil_of_discord_debuff.vpcf"
+end
+
+function modifier_veil_active_debuff:GetEffectAttachType()
+    return PATTACH_ABSORIGIN_FOLLOW
+end
+----------------------------------
+--- PASSIVE STAT/AURA MODIFIER ---
+----------------------------------
+modifier_veil_passive = modifier_veil_passive or class({})
+
+-- Modifier properties
+function modifier_veil_passive:IsHidden() return true end
+function modifier_veil_passive:IsDebuff() return false end
+function modifier_veil_passive:IsPurgable() return false end
+function modifier_veil_passive:IsPermanent() return true end
+function modifier_veil_passive:IsAura() return true end
+
+function modifier_veil_passive:OnCreated()
+    local ability   =   self:GetAbility()
+
+    -- Ability parameters
+    self.int_bonus              =   ability:GetSpecialValueFor("bonus_int")
+    self.str_bonus              =   ability:GetSpecialValueFor("bonus_str")
+    self.agi_bonus              =   ability:GetSpecialValueFor("bonus_agi")
+    self.hp_regen_bonus         =   ability:GetSpecialValueFor("bonus_health_regen")
+    self.armor_bonus            =   ability:GetSpecialValueFor("bonus_armor")
+    self.attack_damage_bonus    =   ability:GetSpecialValueFor("bonus_attack_damage")
+
+end
+
+-- Various stat bonuses
+function modifier_veil_passive:DeclareFunctions()
+    local funcs =   {
+        MODIFIER_PROPERTY_STATS_INTELLECT_BONUS,
+        MODIFIER_PROPERTY_STATS_AGILITY_BONUS,
+        MODIFIER_PROPERTY_STATS_STRENGTH_BONUS,
+        MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT,
+        MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
+        MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE
+    }
+    return funcs
+end
+
+function modifier_veil_passive:GetModifierBonusStats_Intellect() return self.int_bonus end
+function modifier_veil_passive:GetModifierBonusStats_Agility() return self.agi_bonus end
+function modifier_veil_passive:GetModifierBonusStats_Strength() return self.str_bonus end
+function modifier_veil_passive:GetModifierConstantHealthRegen() return self.hp_regen_bonus end
+function modifier_veil_passive:GetModifierPhysicalArmorBonus() return self.armor_bonus end
+function modifier_veil_passive:GetModifierPreAttack_BonusDamage() return self.attack_damage_bonus end
+
+--- AURA
+function modifier_veil_passive:GetAuraSearchTeam()
+    return DOTA_UNIT_TARGET_TEAM_ENEMY end
+
+function modifier_veil_passive:GetAuraSearchType()
+    return DOTA_UNIT_TARGET_CREEP + DOTA_UNIT_TARGET_HERO end
+
+function modifier_veil_passive:GetModifierAura()
+    return "modifier_veil_aura" end
+
+function modifier_veil_passive:GetAuraRadius()
+    return self:GetAbility():GetSpecialValueFor("aura_radius") end
+
+--- AURA MODIFIER
+modifier_veil_aura = modifier_veil_aura or class({})
+
+-- Modifier properties
+function modifier_veil_aura:IsDebuff() return true end
+function modifier_veil_aura:IsHidden() return false end
+function modifier_veil_aura:IsPurgable() return false end
+
+function modifier_veil_aura:OnCreated()
+    self.magic_resis    =   self:GetAbility():GetSpecialValueFor("aura_resist")
+end
+function modifier_veil_aura:DeclareFunctions()
+    local funcs =   {
+        MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS
+    }
+    return funcs
+end
+
+function modifier_veil_aura:GetModifierMagicalResistanceBonus()
+    return self.magic_resis
+end


### PR DESCRIPTION
REWORKED VEIL:
OLD: (Datadriven)
+14 int
+6  hp regen
+8 armor
Passively provides a 900 radius aura that reduces magic resistance by 20%
Can be activated to double the aura's effect on a single target (8 sec duration, 20 sec cd)


NEW: (Lua)
+14 int
+6 str
+6 agi
+6 hp regen
+8 armor
+6 attack damage

Active: Magic Weakness:  Cast a 600 radius blast that decreases enemies' magic resistance by 10% for 8 seconds.  Also grants alies in the radius 10 spell power for 8 seconds. 20 seconds cooldown.
Passive: Magic Absolution: Grants an aura that reduces the magic resistance of enemies in a 900 radius by an additional 25%. (same as old)