### PR TITLE
Fix to Rubick

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_lycan.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_lycan.lua
@@ -187,6 +187,11 @@ function modifier_imba_lycan_wolf_charge:AllowIllusionDuplicate()
 end
 
 function modifier_imba_lycan_wolf_charge:RemoveOnDeath()
+	--remove if the ability was stolen via Rubick's ulti. 
+	--Needed to prevent a bug where the buff would stay on permanently even after losing the ability on death
+	if self.ability:IsStolen() then
+		return true
+	end
 	return false
 end
 


### PR DESCRIPTION
Fixed a bug where if Rubick stole Lycan's Summon Wolves, he would retain the Wolf Pack buff even after losing the ability on death.

Sorry fam... Lycan's crew howls are more than enough to handle :)